### PR TITLE
Fix sorting of aliases by name

### DIFF
--- a/src/OpinionatedUsings.Tests/TestInspection.cs
+++ b/src/OpinionatedUsings.Tests/TestInspection.cs
@@ -1,8 +1,7 @@
 using CSharpSyntaxTree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree;
-
-using System.Linq;  // can't alias
-
-using NUnit.Framework;  // can't alias
+using System.Linq; // can't alias
+using NUnit.Framework;
+using NUnit.Framework.Internal; // can't alias
 
 namespace OpinionatedUsings.Tests
 {
@@ -161,9 +160,9 @@ namespace OpinionatedUsings.Tests
             Assert.AreEqual(1, records.First().Errors.Count);
 
             Assert.AreEqual(
-                "Expected aliased using " +
-                "directive \"using File = System.IO.File;\" before " +
-                "the previous aliased using " +
+                "Expected the alias \"File\" from the using " +
+                "directive \"using File = System.IO.File;\" before the previous " +
+                "alias \"Path\" from the using " +
                 "directive \"using Path = System.IO.Path;\" " +
                 "at line 1 (by alphabetical order).",
                 records.First().Errors.First());
@@ -172,7 +171,7 @@ namespace OpinionatedUsings.Tests
         [Test]
         public void Test_pass_common_case()
         {
-            string programText =
+            const string programText =
                 "using File = System.IO.File;\n" +
                 "using Path = System.IO.Path;\n" +
                 "using SystemUri = System.Uri;  // renamed\n" +
@@ -188,8 +187,8 @@ namespace OpinionatedUsings.Tests
         [Test]
         public void Test_pass_trailing_comments_on_separate_lines_are_ok()
         {
-            string programText = "using File = System.IO.File;\n" +
-                                 "// unknown";
+            const string programText = "using File = System.IO.File;\n" +
+                                       "// unknown";
             var tree = CSharpSyntaxTree.ParseText(programText);
 
             var records = Inspection.Inspect(tree).ToList();
@@ -199,9 +198,20 @@ namespace OpinionatedUsings.Tests
         [Test]
         public void Test_pass_non_aliased_usings_not_sorted()
         {
-            string programText =
+            const string programText =
                 "using System.Linq;   // can't alias\n" +
                 "using System.Collections.Generic;  // can't alias\n";
+            var tree = CSharpSyntaxTree.ParseText(programText);
+
+            var records = Inspection.Inspect(tree).ToList();
+            Assert.AreEqual(0, records.Count);
+        }
+
+        [Test]
+        public void Test_aliased_are_sorted_by_aliases()
+        {
+            const string programText = "using Directory = System.IO.Directory;\n" +
+                                       "using Environment = System.Environment;";
             var tree = CSharpSyntaxTree.ParseText(programText);
 
             var records = Inspection.Inspect(tree).ToList();

--- a/src/OpinionatedUsings.Tests/TestProgram.cs
+++ b/src/OpinionatedUsings.Tests/TestProgram.cs
@@ -102,26 +102,24 @@ namespace OpinionatedUsings.Tests
 
                 Assert.AreEqual(1, exitCode);
 
+                string gotOut = consoleCapture.Output()
+                    .Replace(path, "<path>")
+                    .Replace("\r\n", "\n");
+
+                string gotErr = consoleCapture.Error()
+                    .Replace(path, "<path>")
+                    .Replace("\r\n", "\n");
+
                 string outputPath = Path.Join(caseDir, "ExpectedOutput.txt");
                 string expectedOut = File.ReadAllText(outputPath)
-                    .Replace(path, "<path>")
                     .Replace("\r\n", "\n");
 
                 string errPath = Path.Join(caseDir, "ExpectedError.txt");
                 string expectedErr = File.ReadAllText(errPath)
-                    .Replace(path, "<path>")
                     .Replace("\r\n", "\n");
 
-                Assert.AreEqual(
-                    expectedOut,
-                    consoleCapture.Output()
-                        .Replace(path, "<path>")
-                        .Replace("\r\n", "\n"));
-                Assert.AreEqual(
-                    expectedErr,
-                    consoleCapture.Error()
-                        .Replace(path, "<path>")
-                        .Replace("\r\n", "\n"));
+                Assert.AreEqual(expectedOut, gotOut);
+                Assert.AreEqual(expectedErr, gotErr);
             }
         }
     }

--- a/src/OpinionatedUsings.Tests/TestResources/OpinionatedUsings.Tests/fails/outcast_usings/ExpectedError.txt
+++ b/src/OpinionatedUsings.Tests/TestResources/OpinionatedUsings.Tests/fails/outcast_usings/ExpectedError.txt
@@ -2,8 +2,8 @@ FAILED: <path>
  * Line 1, column 1:
    * Expected an aliased using directive "using SysFile = System.IO.File;" with the alias different from the name to have the marking comment `// renamed`, but found no marking comment.
  * Line 3, column 1:
-   * Unrecognized marking comment for the using directive "using SystemUri = System.Uri;": " // unknown"
+   * Unrecognized marking comment for the using directive "using SystemUri = System.Uri;": " // unknown\n"
  * Line 5, column 1:
-   * Expected a non-aliased using directive "using System.Linq;" to be explicitly marked with `// can't alias` comment, but found the marking: "  // renamed"
+   * Expected a non-aliased using directive "using System.Linq;" to be explicitly marked with `// can't alias` comment, but found the marking: "  // renamed\n"
 
 One or more using directives in your code base do not conform to the expected style. Please see above.

--- a/src/OpinionatedUsings/Inspection.cs
+++ b/src/OpinionatedUsings/Inspection.cs
@@ -318,8 +318,8 @@ namespace OpinionatedUsings
 
             if (previousAliased != null
                 && string.Compare(
-                    previousAliased.Name.ToString(),
-                    node.Name.ToString(),
+                    previousAliased.Alias.Name.ToString(),
+                    node.Alias.ToString(),
                     StringComparison.InvariantCulture) > 0)
             {
                 var line = previousAliased
@@ -328,9 +328,12 @@ namespace OpinionatedUsings
                     .StartLinePosition.Line;
 
                 (result ??= new List<string>()).Add(
-                    $"Expected aliased using directive " +
+                    $"Expected the alias {Quote(node.Alias.Name.ToString())} " +
+                    $"from the using directive " +
                     $"{Quote(node.ToString().TrimEnd())} " +
-                    $"before the previous aliased using directive " +
+                    $"before the previous " +
+                    $"alias {Quote(previousAliased.Alias.Name.ToString())} " +
+                    $"from the using directive " +
                     Quote(previousAliased.ToString().TrimEnd()) +
                     $" at line {line + 1} (by alphabetical order).");
             }

--- a/src/opinionated-usings.sln.DotSettings.user
+++ b/src/opinionated-usings.sln.DotSettings.user
@@ -12,8 +12,7 @@
 &lt;/SessionState&gt;</s:String>
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=ffa65234_002Da6de_002D4d2c_002D917b_002D9bdb6586b522/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test_with_valid_usings #3" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
   &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::754392CE-94CE-4AA0-B316-E915993B96B3::net5.0::OpinionatedUsings.Tests.InspectTests&lt;/TestId&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::754392CE-94CE-4AA0-B316-E915993B96B3::net5.0::OpinionatedUsings.Tests.ProgramTests.Test_outcast_using_directives_reported&lt;/TestId&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::754392CE-94CE-4AA0-B316-E915993B96B3::net5.0::OpinionatedUsings.Tests.ProgramTests.Test_recorded_output_on_fails&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::754392CE-94CE-4AA0-B316-E915993B96B3::.NETCoreApp,Version=v3.1::OpinionatedUsings.Tests.InspectTests&lt;/TestId&gt;&#xD;
+    &lt;TestId&gt;NUnit3x::754392CE-94CE-4AA0-B316-E915993B96B3::.NETCoreApp,Version=v3.1::OpinionatedUsings.Tests.ProgramTests.Test_recorded_output_on_fails&lt;/TestId&gt;&#xD;
   &lt;/TestAncestor&gt;&#xD;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
Previously, the aliases by sorted by the name of the module instead of
the alias.