### PR TITLE
Install same SDKs in publish and check workflows

### DIFF
--- a/.github/workflows/publish-to-nuget.yml
+++ b/.github/workflows/publish-to-nuget.yml
@@ -16,11 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
 
-
-      - name: Install NET 5
+      - name: Install .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.202'
+          dotnet-version: '3.1.100'
 
       - name: Build solution and generate NuGet package
         working-directory: src


### PR DESCRIPTION
The SDK versions were different in publish and check workflows (NET 5
and .NET Core 3, respectively) by mistake.